### PR TITLE
Fix wrong executable issue on MacBook M series

### DIFF
--- a/src/main/kotlin/com/cppcxy/ide/lsp/SumnekoAdaptor.kt
+++ b/src/main/kotlin/com/cppcxy/ide/lsp/SumnekoAdaptor.kt
@@ -19,7 +19,7 @@ object SumnekoAdaptor {
             return if (SystemInfoRt.isWindows) {
                 "win32-x64/bin/lua-language-server.exe"
             } else if (SystemInfoRt.isMac) {
-                if (System.getProperty("os.arch") == "arm64") {
+                if (System.getProperty("os.arch") == "aarch64") {
                     "darwin-arm64/bin/lua-language-server"
                 } else {
                     "darwin-x64/bin/lua-language-server"


### PR DESCRIPTION
The plugin was failing with an executable issue and I realized that it was pointing out to `darwin-x64/bin/lua-language-server` while my laptop is M2. I have already built the extension with this patch on my local environment and using the plugin without issues. I wanted to share the fix so everyone can benefit from it.

The issue I've encountered:
```
com.redhat.devtools.lsp4ij.server.CannotStartProcessException: Unable to start language server: ProcessStreamConnectionProvider [commands=[/Users/yozel/Library/Application Support/JetBrains/GoLand2025.2/plugins/Sumneko-Lua/server/darwin-x64/bin/lua-language-server, --locale=en-us], workingDir=null]
	at com.redhat.devtools.lsp4ij.server.ProcessStreamConnectionProvider.ensureIsAlive(ProcessStreamConnectionProvider.java:88)
	at com.redhat.devtools.lsp4ij.LanguageServerWrapper.lambda$start$3(LanguageServerWrapper.java:359)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1491)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:2073)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2035)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
```

Here's what my `os.arch` is
```
$ java -XshowSettings:properties -version 2>&1 | grep os.arch
os.arch = aarch64
```